### PR TITLE
Upgrade to public_suffix 2.0

### DIFF
--- a/PageRankr.gemspec
+++ b/PageRankr.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "nokogiri",              ">= 1.4.1"
   s.add_runtime_dependency "json",                  ">= 1.4.6"
-  s.add_runtime_dependency "public_suffix",         "~> 1.5.1"
+  s.add_runtime_dependency "public_suffix",         "~> 2.0"
   s.add_runtime_dependency "httparty",              ">= 0.9.0"
   s.add_runtime_dependency "jsonpath",              ">= 0.4.2"
 

--- a/lib/page_rankr/site.rb
+++ b/lib/page_rankr/site.rb
@@ -9,9 +9,9 @@ module PageRankr
     def initialize(site)
       site = "http://#{site}" unless site =~ /:\/\//
       @uri = URI.parse(site)
-      @domain = PublicSuffix.parse(@uri.host || "")
+      @domain = PublicSuffix.parse(@uri.host || "", default_rule: nil)
 
-      @domain.valid? or raise DomainInvalid, "The domain provided is invalid.1"
+      PublicSuffix.valid?(@domain, default_rule: nil) or raise DomainInvalid, "The domain provided is invalid.1"
     rescue PublicSuffix::DomainInvalid, URI::InvalidURIError
       raise DomainInvalid, "The domain provided is invalid."
     end


### PR DESCRIPTION
Re: https://trello.com/c/IJZ8a0qP

See also: https://github.com/clearbit/validators/pull/12

Required for `company` to use the latest `validators` gem, which depends on `public_suffix ~> 2.0` 

Passing `default_rule: nil` to get the specs passing by emulating the 1.x `public_suffix` behavior. 
